### PR TITLE
Added flags to support customizing output properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ and downloading it from the `Get packages & executable files` section.
 pip install turbo-potato
 ```
 
+## Advanced Usage
+
+`turbo-potato` supports the following command line options to customize compression settings:
+- `--target-size`: the target size of the output file in megabytes (MB). The output file will be no larger than this value.
+  - The default is 8MB.
+- `--max-fps`: the maximum FPS that your output will have. If your input file has a higher FPS than this value then the
+output file's FPS will be forced to this value.
+  - This option is not active by default.
+- `--max-resolution`: the maximum resolution that your output will have. If your input file has a higher resolution than
+this value, then the output file's resolution will be forced to this value.
+  - This option is not active by default.
+  - This option will do its best not to mess with the input file's aspect ratio
+
 ## How it Works
 
 The script uses the Two-Pass rate control mode of the `ffmpeg` H.264 encoder. You can read about it

--- a/turbo_potato/turbo_potato.py
+++ b/turbo_potato/turbo_potato.py
@@ -9,11 +9,21 @@ TARGET_FILE_SIZE_kb = 8 * 8 * 1000  # 8MB * 8b/B * 1000 kb/Mb
 AUDIO_BITRATE_kbPS = 128
 MARGIN = 0.98
 
+class Options:
+    def __init__(self, output_name, max_fps):
+        self.output_name = output_name
+        self.max_fps = max_fps
 
-def compress(input_path, output_name):
+
+class Attributes:
+    def __init__(self, duration_seconds, fps):
+        self.duration_seconds = duration_seconds
+        self.fps = fps
+
+def compress(input_path, options):
     with tempfile.TemporaryDirectory() as temp_dir:
-        output_path = pathlib.Path(temp_dir).joinpath(output_name).with_suffix(".mp4")
-        compress_with_directory(temp_dir, input_path, output_path)
+        output_path = pathlib.Path(temp_dir).joinpath(options.output_name).with_suffix(".mp4")
+        compress_with_directory(temp_dir, input_path, output_path, options)
 
         r = tkinter.Tk()
         r.withdraw()
@@ -26,19 +36,35 @@ def compress(input_path, output_name):
         r.destroy()
 
 
-def compress_with_directory(working_directory, input_path, output_path):
-    duration_string = subprocess.check_output(["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", input_path])
-    duration_seconds = float(duration_string)
-    bitrate = int(TARGET_FILE_SIZE_kb / duration_seconds * MARGIN) - AUDIO_BITRATE_kbPS
+def compress_with_directory(working_directory, input_path, output_path, options):
+    attributes = get_input_attributes(input_path)
+    bitrate = int(TARGET_FILE_SIZE_kb / attributes.duration_seconds * MARGIN) - AUDIO_BITRATE_kbPS
     base_command = ["ffmpeg", "-y", "-i", input_path, "-c:v", "libx264", "-b:v", f"{bitrate}k"]
+    if options.max_fps is not None and options.max_fps < attributes.fps:
+        base_command.extend(["-filter:v", f"fps=fps={options.max_fps}"])
     subprocess.check_call(base_command + ["-pass", "1", "-an", "-f", "null", "NUL"], cwd=working_directory)
     subprocess.check_call(base_command + ["-pass", "2", "-c:a", "aac", "-b:a", f"{AUDIO_BITRATE_kbPS}k", output_path], cwd=working_directory)
+
+def get_input_attributes(input_path):
+    entries_string = subprocess.check_output(
+        ["ffprobe", "-v", "error", "-select_streams", "0", "-show_entries", "format=duration:stream=r_frame_rate",
+         "-of", "default=noprint_wrappers=1", input_path]).decode()
+    entries_list = entries_string.strip().splitlines()
+    entries = {}
+    for entry in entries_list:
+        keyval = entry.split('=')
+        entries[keyval[0]] = keyval[1]
+    duration_seconds = float(entries["duration"])
+    fps_fraction = entries["r_frame_rate"].split('/')
+    fps = float(fps_fraction[0])/float(fps_fraction[1])
+    return Attributes(duration_seconds, fps)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", help="the file to read the video from")
     parser.add_argument("--name", help="the the name of the resulting mp4 file")
+    parser.add_argument("--max-fps", type=int, help="reduce the output's frame rate to the given value if it exceeds it")
 
     args = parser.parse_args()
 
@@ -55,7 +81,9 @@ def main():
     if output_name == "":
         output_name = "output"
 
-    compress(input_path, output_name)
+    options = Options(output_name, args.max_fps)
+
+    compress(input_path, options)
 
 
 if __name__ == '__main__':

--- a/turbo_potato/turbo_potato.py
+++ b/turbo_potato/turbo_potato.py
@@ -122,22 +122,12 @@ def make_resolution_options(attributes, options):
     if max_dimension >= largest_dimension:
         return None
     command_options = ["-vf"]
-    scale = max_dimension / largest_dimension
     if attributes.width > attributes.height:
-        height = round(attributes.height * scale)
-        command_options.append(f"scale={max_dimension}:{force_divisible_by_two(height)}")
+        command_options.append(f"scale={max_dimension}:-1")
     else:
-        width = round(attributes.width * scale)
-        command_options.append(f"scale={force_divisible_by_two(width)}:{max_dimension}")
+        command_options.append(f"scale=-1:{max_dimension}")
 
     return command_options
-
-
-def force_divisible_by_two(value):
-    if value % 2 == 0:
-        return value
-    else:
-        return value - 1
 
 
 def main():


### PR DESCRIPTION
Adds configuration for:
- target file size: `--target-size`
- maximum resolution: `--max-resolution`
- maximum fps: `--max-fps`

```
> turbo-potato.exe -h
usage: turbo-potato [-h] [--input INPUT] [--name NAME] [--target-size TARGET_SIZE] [--max-fps MAX_FPS]
                    [--max-resolution {4K,UHD,2160p,2K,1440,1440p,HD,1080,1080p,480,408p,360,360p,240,240p}]

options:
  -h, --help            show this help message and exit
  --input INPUT         the file to read the video from
  --name NAME           the the name of the resulting mp4 file
  --target-size TARGET_SIZE
                        the target output file size in megabytes. i.e. 8, 50, 500
  --max-fps MAX_FPS     reduce the output's frame rate to the given value if it exceeds it
  --max-resolution {4K,UHD,2160p,2K,1440,1440p,HD,1080,1080p,480,408p,360,360p,240,240p}
                        reduce the output's resolution to the given value if it exceeds it
```